### PR TITLE
Start migration towards public IDs for app/org caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ See the \`flyio\` package for more details.
 - [func IsAttestation\(c Caveat\) bool](<#IsAttestation>)
 - [func Parse\(header string\) \(\[\]\[\]byte, error\)](<#Parse>)
 - [func ParsePermissionAndDischargeTokens\(header string, location string\) \(\[\]byte, \[\]\[\]byte, error\)](<#ParsePermissionAndDischargeTokens>)
+- [func RegisterCaveatJSONAlias\(typ CaveatType, alias string\)](<#RegisterCaveatJSONAlias>)
 - [func RegisterCaveatType\(zeroValue Caveat\)](<#RegisterCaveatType>)
 - [func ThirdPartyCID\(encodedMacaroon \[\]byte, thirdPartyLocation string\) \(\[\]byte, error\)](<#ThirdPartyCID>)
 - [func ToAuthorizationHeader\(toks ...\[\]byte\) string](<#ToAuthorizationHeader>)
@@ -130,29 +131,6 @@ See the \`flyio\` package for more details.
 
 ## Constants
 
-<a name="CavValidityWindow"></a>
-
-```go
-const (
-    CavValidityWindow
-
-    Cav3P
-    CavBindToParentToken
-    CavIfPresent
-
-    // Globally-recognized user-registerable caveat types may be requested via
-    // pull requests to this repository. Add a meaningful name of the caveat
-    // type (e.g. CavAcmeCorpWidgetID) on the line prior to
-    // CavMaxUserRegisterable.
-    CavMinUserRegisterable = 1 << 32
-    CavMaxUserRegisterable = 1<<48 - 1
-
-    CavMinUserDefined = 1 << 48
-    CavMaxUserDefined = 1<<64 - 2
-    CavUnregistered   = 1<<64 - 1
-)
-```
-
 <a name="EncryptionKeySize"></a>
 
 ```go
@@ -167,11 +145,10 @@ const (
 
 ```go
 var (
-    ErrUnrecognizedToken          = errors.New("bad token")
-    ErrUnauthorized               = errors.New("unauthorized")
-    ErrInvalidAccess              = fmt.Errorf("%w: bad data for token verification", ErrUnauthorized)
-    ErrResourcesMutuallyExclusive = fmt.Errorf("%w: resources are mutually exclusive", ErrInvalidAccess)
-    ErrBadCaveat                  = fmt.Errorf("%w: bad caveat", ErrUnauthorized)
+    ErrUnrecognizedToken = errors.New("bad token")
+    ErrUnauthorized      = errors.New("unauthorized")
+    ErrInvalidAccess     = fmt.Errorf("%w: bad data for token verification", ErrUnauthorized)
+    ErrBadCaveat         = fmt.Errorf("%w: bad caveat", ErrUnauthorized)
 )
 ```
 
@@ -228,6 +205,15 @@ func ParsePermissionAndDischargeTokens(header string, location string) ([]byte, 
 ```
 
 Parse a string token and find the contained permission token for the given location.
+
+<a name="RegisterCaveatJSONAlias"></a>
+## func RegisterCaveatJSONAlias
+
+```go
+func RegisterCaveatJSONAlias(typ CaveatType, alias string)
+```
+
+Register an alternate name for this caveat type that will be recognized when decoding JSON.
 
 <a name="RegisterCaveatType"></a>
 ## func RegisterCaveatType
@@ -485,6 +471,41 @@ A numeric identifier for caveat types. Values less than CavMinUserRegisterable \
 
 ```go
 type CaveatType uint64
+```
+
+<a name="CavFlyioOrganization"></a>
+
+```go
+const (
+    CavFlyioOrganization CaveatType = iota
+
+    CavFlyioVolumes
+    CavFlyioApps
+    CavValidityWindow
+    CavFlyioFeatureSet
+    CavFlyioMutations
+    CavFlyioMachines
+    CavFlyioConfineUser
+    CavFlyioConfineOrganization
+    CavFlyioIsUser
+    Cav3P
+    CavBindToParentToken
+    CavIfPresent
+    CavFlyioMachineFeatureSet
+    CavFlyioFromMachineSource
+    CavFlyioClusters
+
+    // Globally-recognized user-registerable caveat types may be requested via
+    // pull requests to this repository. Add a meaningful name of the caveat
+    // type (e.g. CavAcmeCorpWidgetID) on the line prior to
+    // CavMaxUserRegisterable.
+    CavMinUserRegisterable = 1 << 32
+    CavMaxUserRegisterable = 1<<48 - 1
+
+    CavMinUserDefined = 1 << 48
+    CavMaxUserDefined = 1<<64 - 2
+    CavUnregistered   = 1<<64 - 1
+)
 ```
 
 <a name="EncryptionKey"></a>

--- a/caveat.go
+++ b/caveat.go
@@ -13,23 +13,23 @@ import (
 type CaveatType uint64
 
 const (
-	_ CaveatType = iota // fly.io reserved
-	_                   // fly.io reserved
-	_                   // fly.io reserved
-	_                   // fly.io reserved
+	CavFlyioOrganization CaveatType = iota
+	_                               // deprecated
+	CavFlyioVolumes
+	CavFlyioApps
 	CavValidityWindow
-	_ // fly.io reserved
-	_ // fly.io reserved
-	_ // fly.io reserved
-	_ // fly.io reserved
-	_ // fly.io reserved
-	_ // fly.io reserved
+	CavFlyioFeatureSet
+	CavFlyioMutations
+	CavFlyioMachines
+	CavFlyioConfineUser
+	CavFlyioConfineOrganization
+	CavFlyioIsUser
 	Cav3P
 	CavBindToParentToken
 	CavIfPresent
-	_ // fly.io reserved
-	_ // fly.io reserved
-	_ // fly.io reserved
+	CavFlyioMachineFeatureSet
+	CavFlyioFromMachineSource
+	CavFlyioClusters
 	_ // fly.io reserved
 	_ // fly.io reserved
 

--- a/caveat.go
+++ b/caveat.go
@@ -109,6 +109,18 @@ func RegisterCaveatType(zeroValue Caveat) {
 	s2t[name] = typ
 }
 
+// Register an alternate name for this caveat type that will be recognized when
+// decoding JSON.
+func RegisterCaveatJSONAlias(typ CaveatType, alias string) {
+	if _, dup := s2t[alias]; dup {
+		panic("duplicate caveat type")
+	}
+	if _, exist := t2s[typ]; !exist {
+		panic("unregistered caveat type")
+	}
+	s2t[alias] = typ
+}
+
 func typeToCaveat(t CaveatType) (Caveat, error) {
 	cav, ok := t2c[t]
 	if !ok {

--- a/caveat_test.go
+++ b/caveat_test.go
@@ -1,0 +1,33 @@
+package macaroon
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestCaveatRegistry(t *testing.T) {
+	var (
+		c  Caveat = &testCaveatParentResource{ID: 123, Permission: ActionRead}
+		j1        = []byte(`[{"type":"ParentResource", "body":{"ID": 123, "Permission": 1}}]`)
+		j2        = []byte(`[{"type":"Foobar", "body":{"ID": 123, "Permission": 1}}]`)
+		cs        = new(CaveatSet)
+	)
+
+	assert.NoError(t, json.Unmarshal(j1, cs))
+	assert.Equal(t, 1, len(cs.Caveats))
+	assert.Equal(t, c, cs.Caveats[0])
+
+	assert.Error(t, json.Unmarshal(j2, cs))
+
+	RegisterCaveatJSONAlias(cavTestParentResource, "Foobar")
+
+	assert.NoError(t, json.Unmarshal(j1, cs))
+	assert.Equal(t, 1, len(cs.Caveats))
+	assert.Equal(t, c, cs.Caveats[0])
+
+	assert.NoError(t, json.Unmarshal(j2, cs))
+	assert.Equal(t, 1, len(cs.Caveats))
+	assert.Equal(t, c, cs.Caveats[0])
+}

--- a/errors.go
+++ b/errors.go
@@ -6,9 +6,8 @@ import (
 )
 
 var (
-	ErrUnrecognizedToken          = errors.New("bad token")
-	ErrUnauthorized               = errors.New("unauthorized")
-	ErrInvalidAccess              = fmt.Errorf("%w: bad data for token verification", ErrUnauthorized)
-	ErrResourcesMutuallyExclusive = fmt.Errorf("%w: resources are mutually exclusive", ErrInvalidAccess)
-	ErrBadCaveat                  = fmt.Errorf("%w: bad caveat", ErrUnauthorized)
+	ErrUnrecognizedToken = errors.New("bad token")
+	ErrUnauthorized      = errors.New("unauthorized")
+	ErrInvalidAccess     = fmt.Errorf("%w: bad data for token verification", ErrUnauthorized)
+	ErrBadCaveat         = fmt.Errorf("%w: bad caveat", ErrUnauthorized)
 )

--- a/flyio/access.go
+++ b/flyio/access.go
@@ -2,6 +2,7 @@ package flyio
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/superfly/macaroon"
@@ -9,16 +10,20 @@ import (
 )
 
 type Access struct {
-	OrgID          uint64        `json:"orgid"`
-	AppID          *uint64       `json:"appid"`
-	Action         resset.Action `json:"action"`
-	Feature        *string       `json:"feature"`
-	Volume         *string       `json:"volume"`
-	Machine        *string       `json:"machine"`
-	MachineFeature *string       `json:"machine_feature"`
-	Mutation       *string       `json:"mutation"`
-	SourceMachine  *string       `json:"sourceMachine"`
-	Cluster        *string       `json:"cluster"`
+	OrgSlug        *string       `json:"org_slug,omitempty"`
+	AppID          *string       `json:"apphid,omitempty"`
+	Action         resset.Action `json:"action,omitempty"`
+	Feature        *string       `json:"feature,omitempty"`
+	Volume         *string       `json:"volume,omitempty"`
+	Machine        *string       `json:"machine,omitempty"`
+	MachineFeature *string       `json:"machine_feature,omitempty"`
+	Mutation       *string       `json:"mutation,omitempty"`
+	SourceMachine  *string       `json:"sourceMachine,omitempty"`
+	Cluster        *string       `json:"cluster,omitempty"`
+
+	// deprecated
+	DeprecatedOrgID *uint64 `json:"orgid,omitempty"`
+	DeprecatedAppID *uint64 `json:"appid,omitempty"`
 }
 
 var (
@@ -43,18 +48,29 @@ func (a *Access) Now() time.Time {
 // This ensure that a Access represents a single action taken on a single object.
 func (f *Access) Validate() error {
 	// root-level resources = org
-	if f.OrgID == 0 {
+	if f.DeprecatedOrgID == nil && f.OrgSlug == nil {
 		return fmt.Errorf("%w org", resset.ErrResourceUnspecified)
 	}
 
-	// org-level resources = apps, features
-	if f.AppID != nil && f.Feature != nil {
-		return fmt.Errorf("%w: app, feature", macaroon.ErrResourcesMutuallyExclusive)
+	hasApp := f.DeprecatedAppID != nil || f.AppID != nil
+
+	var orgLevelResources []string
+	if hasApp {
+		orgLevelResources = append(orgLevelResources, "app")
+	}
+	if f.Feature != nil {
+		orgLevelResources = append(orgLevelResources, "org-feature")
+	}
+	if f.Cluster != nil {
+		orgLevelResources = append(orgLevelResources, "litefs cluster")
+	}
+	if len(orgLevelResources) > 1 {
+		return fmt.Errorf("%w: %s", macaroon.ErrResourcesMutuallyExclusive, strings.Join(orgLevelResources, ", "))
 	}
 
 	// app-level resources = machines, volumes
 	if f.Machine != nil || f.Volume != nil {
-		if f.AppID == nil {
+		if !hasApp {
 			return fmt.Errorf("%w app", resset.ErrResourceUnspecified)
 		}
 

--- a/flyio/access_test.go
+++ b/flyio/access_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
-	"github.com/superfly/macaroon"
 	"github.com/superfly/macaroon/resset"
 )
 
@@ -14,7 +13,7 @@ func TestAccess(t *testing.T) {
 
 	// orgid required
 	assertError(t, resset.ErrResourceUnspecified, (&Access{}).Validate())
-	assertError(t, noError, (&Access{
+	assertError(t, resset.ErrResourceUnspecified, (&Access{
 		OrgSlug: ptr("x"),
 	}).Validate())
 	assertError(t, noError, (&Access{
@@ -22,57 +21,53 @@ func TestAccess(t *testing.T) {
 	}).Validate())
 
 	// org-level resources are mutually exclusive
-	assertError(t, macaroon.ErrResourcesMutuallyExclusive, (&Access{
-		OrgSlug: ptr("x"),
-		AppID:   ptr("x"),
-		Feature: ptr("x"),
-		Cluster: ptr("x"),
-	}).Validate())
-	assertError(t, macaroon.ErrResourcesMutuallyExclusive, (&Access{
-		OrgSlug: ptr("x"),
-		Feature: ptr("x"),
-		Cluster: ptr("x"),
-	}).Validate())
-	assertError(t, macaroon.ErrResourcesMutuallyExclusive, (&Access{
-		OrgSlug: ptr("x"),
-		AppID:   ptr("x"),
-		Cluster: ptr("x"),
-	}).Validate())
-	assertError(t, macaroon.ErrResourcesMutuallyExclusive, (&Access{
-		OrgSlug:         ptr("x"),
+	assertError(t, resset.ErrResourcesMutuallyExclusive, (&Access{
+		DeprecatedOrgID: uptr(1),
 		DeprecatedAppID: uptr(1),
 		Feature:         ptr("x"),
+		Cluster:         ptr("x"),
 	}).Validate())
-	assertError(t, macaroon.ErrResourcesMutuallyExclusive, (&Access{
-		OrgSlug:         ptr("x"),
+	assertError(t, resset.ErrResourcesMutuallyExclusive, (&Access{
+		DeprecatedOrgID: uptr(1),
+		Feature:         ptr("x"),
+		Cluster:         ptr("x"),
+	}).Validate())
+	assertError(t, resset.ErrResourcesMutuallyExclusive, (&Access{
+		DeprecatedOrgID: uptr(1),
 		DeprecatedAppID: uptr(1),
 		Cluster:         ptr("x"),
 	}).Validate())
-	assertError(t, macaroon.ErrResourcesMutuallyExclusive, (&Access{
-		OrgSlug: ptr("x"),
-		AppID:   ptr("x"),
-		Feature: ptr("x"),
+	assertError(t, resset.ErrResourcesMutuallyExclusive, (&Access{
+		DeprecatedOrgID: uptr(1),
+		DeprecatedAppID: uptr(1),
+		Feature:         ptr("x"),
 	}).Validate())
 	assertError(t, noError, (&Access{
-		OrgSlug: ptr("x"),
-		AppID:   ptr("x"),
-	}).Validate())
-	assertError(t, noError, (&Access{
-		OrgSlug:         ptr("x"),
+		DeprecatedOrgID: uptr(1),
 		DeprecatedAppID: uptr(1),
 	}).Validate())
 	assertError(t, noError, (&Access{
-		OrgSlug: ptr("x"),
-		Feature: ptr("x"),
+		DeprecatedOrgID: uptr(1),
+		DeprecatedAppID: uptr(1),
 	}).Validate())
 	assertError(t, noError, (&Access{
-		OrgSlug: ptr("x"),
-		Cluster: ptr("x"),
+		DeprecatedOrgID: uptr(1),
+		Feature:         ptr("x"),
+	}).Validate())
+	assertError(t, noError, (&Access{
+		DeprecatedOrgID: uptr(1),
+		Cluster:         ptr("x"),
+	}).Validate())
+
+	// can't specify encoded app id without numeric
+	assertError(t, resset.ErrResourceUnspecified, (&Access{
+		DeprecatedOrgID: uptr(1),
+		AppID:           ptr("x"),
 	}).Validate())
 
 	// can (should) specify numeric and encoded app id
 	assertError(t, noError, (&Access{
-		OrgSlug:         ptr("x"),
+		DeprecatedOrgID: uptr(1),
 		AppID:           ptr("x"),
 		DeprecatedAppID: uptr(1),
 	}).Validate())

--- a/flyio/access_test.go
+++ b/flyio/access_test.go
@@ -1,0 +1,97 @@
+package flyio
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/superfly/macaroon"
+	"github.com/superfly/macaroon/resset"
+)
+
+func TestAccess(t *testing.T) {
+	var noError error
+
+	// orgid required
+	assertError(t, resset.ErrResourceUnspecified, (&Access{}).Validate())
+	assertError(t, noError, (&Access{
+		OrgSlug: ptr("x"),
+	}).Validate())
+	assertError(t, noError, (&Access{
+		DeprecatedOrgID: uptr(1),
+	}).Validate())
+
+	// org-level resources are mutually exclusive
+	assertError(t, macaroon.ErrResourcesMutuallyExclusive, (&Access{
+		OrgSlug: ptr("x"),
+		AppID:   ptr("x"),
+		Feature: ptr("x"),
+		Cluster: ptr("x"),
+	}).Validate())
+	assertError(t, macaroon.ErrResourcesMutuallyExclusive, (&Access{
+		OrgSlug: ptr("x"),
+		Feature: ptr("x"),
+		Cluster: ptr("x"),
+	}).Validate())
+	assertError(t, macaroon.ErrResourcesMutuallyExclusive, (&Access{
+		OrgSlug: ptr("x"),
+		AppID:   ptr("x"),
+		Cluster: ptr("x"),
+	}).Validate())
+	assertError(t, macaroon.ErrResourcesMutuallyExclusive, (&Access{
+		OrgSlug:         ptr("x"),
+		DeprecatedAppID: uptr(1),
+		Feature:         ptr("x"),
+	}).Validate())
+	assertError(t, macaroon.ErrResourcesMutuallyExclusive, (&Access{
+		OrgSlug:         ptr("x"),
+		DeprecatedAppID: uptr(1),
+		Cluster:         ptr("x"),
+	}).Validate())
+	assertError(t, macaroon.ErrResourcesMutuallyExclusive, (&Access{
+		OrgSlug: ptr("x"),
+		AppID:   ptr("x"),
+		Feature: ptr("x"),
+	}).Validate())
+	assertError(t, noError, (&Access{
+		OrgSlug: ptr("x"),
+		AppID:   ptr("x"),
+	}).Validate())
+	assertError(t, noError, (&Access{
+		OrgSlug:         ptr("x"),
+		DeprecatedAppID: uptr(1),
+	}).Validate())
+	assertError(t, noError, (&Access{
+		OrgSlug: ptr("x"),
+		Feature: ptr("x"),
+	}).Validate())
+	assertError(t, noError, (&Access{
+		OrgSlug: ptr("x"),
+		Cluster: ptr("x"),
+	}).Validate())
+
+	// can (should) specify numeric and encoded app id
+	assertError(t, noError, (&Access{
+		OrgSlug:         ptr("x"),
+		AppID:           ptr("x"),
+		DeprecatedAppID: uptr(1),
+	}).Validate())
+}
+
+func assertError(tb testing.TB, expected, actual error) {
+	tb.Helper()
+	if expected == nil {
+		assert.NoError(tb, actual)
+	} else {
+		assert.Error(tb, actual)
+		assert.True(tb, errors.Is(actual, expected), "expected %v, got %v", expected, actual)
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func uptr(v uint64) *uint64 {
+	return ptr(v)
+}

--- a/flyio/caveats.go
+++ b/flyio/caveats.go
@@ -61,10 +61,10 @@ func (c *Organization) Prohibits(a macaroon.Access) error {
 	switch {
 	case !isFlyioAccess:
 		return macaroon.ErrInvalidAccess
-	case f.OrgID == 0:
+	case f.DeprecatedOrgID == nil:
 		return fmt.Errorf("%w org", resset.ErrResourceUnspecified)
-	case c.ID != f.OrgID:
-		return fmt.Errorf("%w org %d, only %d", resset.ErrUnauthorizedForResource, f.OrgID, c.ID)
+	case c.ID != *f.DeprecatedOrgID:
+		return fmt.Errorf("%w org %d, only %d", resset.ErrUnauthorizedForResource, f.DeprecatedOrgID, c.ID)
 	case !f.Action.IsSubsetOf(c.Mask):
 		return fmt.Errorf("%w access %s (%s not allowed)", resset.ErrUnauthorizedForAction, f.Action, f.Action.Remove(c.Mask))
 	default:
@@ -117,7 +117,7 @@ func (c *Apps) Prohibits(a macaroon.Access) error {
 	if !isFlyioAccess {
 		return macaroon.ErrInvalidAccess
 	}
-	return c.Apps.Prohibits(f.AppID, f.Action)
+	return c.Apps.Prohibits(f.DeprecatedAppID, f.Action)
 }
 
 type Volumes struct {

--- a/flyio/caveats.go
+++ b/flyio/caveats.go
@@ -8,18 +8,18 @@ import (
 )
 
 const (
-	CavOrganization        = 0
-	CavVolumes             = 2
-	CavApps                = 3
-	CavFeatureSet          = 5
-	CavMutations           = 6
-	CavMachines            = 7
-	CavConfineUser         = 8
-	CavConfineOrganization = 9
-	CavIsUser              = 10
-	CavMachineFeatureSet   = 14
-	CavFromMachineSource   = 15
-	CavClusters            = 16
+	CavOrganization        = macaroon.CavFlyioOrganization
+	CavVolumes             = macaroon.CavFlyioVolumes
+	CavApps                = macaroon.CavFlyioApps
+	CavFeatureSet          = macaroon.CavFlyioFeatureSet
+	CavMutations           = macaroon.CavFlyioMutations
+	CavMachines            = macaroon.CavFlyioMachines
+	CavConfineUser         = macaroon.CavFlyioConfineUser
+	CavConfineOrganization = macaroon.CavFlyioConfineOrganization
+	CavIsUser              = macaroon.CavFlyioIsUser
+	CavMachineFeatureSet   = macaroon.CavFlyioMachineFeatureSet
+	CavFromMachineSource   = macaroon.CavFlyioFromMachineSource
+	CavClusters            = macaroon.CavFlyioClusters
 )
 
 type FromMachine struct {

--- a/flyio/caveats.go
+++ b/flyio/caveats.go
@@ -51,7 +51,11 @@ type Organization struct {
 	Mask resset.Action `json:"mask"`
 }
 
-func init()                                             { macaroon.RegisterCaveatType(&Organization{}) }
+func init() {
+	macaroon.RegisterCaveatType(&Organization{})
+	macaroon.RegisterCaveatJSONAlias(CavOrganization, "DeprecatedOrganization")
+}
+
 func (c *Organization) CaveatType() macaroon.CaveatType { return CavOrganization }
 func (c *Organization) Name() string                    { return "Organization" }
 
@@ -108,7 +112,11 @@ type Apps struct {
 	Apps resset.ResourceSet[uint64] `json:"apps"`
 }
 
-func init()                                     { macaroon.RegisterCaveatType(&Apps{}) }
+func init() {
+	macaroon.RegisterCaveatType(&Apps{})
+	macaroon.RegisterCaveatJSONAlias(CavApps, "DeprecatedApps")
+}
+
 func (c *Apps) CaveatType() macaroon.CaveatType { return CavApps }
 func (c *Apps) Name() string                    { return "Apps" }
 

--- a/go.mod
+++ b/go.mod
@@ -3,20 +3,17 @@ module github.com/superfly/macaroon
 go 1.20
 
 require (
-	github.com/alecthomas/assert/v2 v2.1.0
+	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/google/uuid v1.3.0
-	github.com/stretchr/testify v1.8.4
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	golang.org/x/crypto v0.12.0
 	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
 )
 
 require (
-	github.com/alecthomas/repr v0.1.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/alecthomas/repr v0.2.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
-github.com/alecthomas/assert/v2 v2.1.0 h1:tbredtNcQnoSd3QBhQWI7QZ3XHOVkw1Moklp2ojoH/0=
-github.com/alecthomas/assert/v2 v2.1.0/go.mod h1:b/+1DI2Q6NckYi+3mXyH3wFb8qG37K/DuK80n7WefXA=
 github.com/alecthomas/assert/v2 v2.3.0 h1:mAsH2wmvjsuvyBvAmCtm7zFsBlb8mIHx5ySLVdDZXL0=
 github.com/alecthomas/assert/v2 v2.3.0/go.mod h1:pXcQ2Asjp247dahGEmsZ6ru0UVwnkhktn7S0bBDLxvQ=
-github.com/alecthomas/repr v0.1.0 h1:ENn2e1+J3k09gyj2shc0dHr/yjaWSHRlrJ4DPMevDqE=
-github.com/alecthomas/repr v0.1.0/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
 github.com/alecthomas/repr v0.2.0 h1:HAzS41CIzNW5syS8Mf9UwXhNH1J9aix/BvDRf1Ml2Yk=
 github.com/alecthomas/repr v0.2.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,13 @@
 github.com/alecthomas/assert/v2 v2.1.0 h1:tbredtNcQnoSd3QBhQWI7QZ3XHOVkw1Moklp2ojoH/0=
 github.com/alecthomas/assert/v2 v2.1.0/go.mod h1:b/+1DI2Q6NckYi+3mXyH3wFb8qG37K/DuK80n7WefXA=
+github.com/alecthomas/assert/v2 v2.3.0 h1:mAsH2wmvjsuvyBvAmCtm7zFsBlb8mIHx5ySLVdDZXL0=
+github.com/alecthomas/assert/v2 v2.3.0/go.mod h1:pXcQ2Asjp247dahGEmsZ6ru0UVwnkhktn7S0bBDLxvQ=
 github.com/alecthomas/repr v0.1.0 h1:ENn2e1+J3k09gyj2shc0dHr/yjaWSHRlrJ4DPMevDqE=
 github.com/alecthomas/repr v0.1.0/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
+github.com/alecthomas/repr v0.2.0 h1:HAzS41CIzNW5syS8Mf9UwXhNH1J9aix/BvDRf1Ml2Yk=
+github.com/alecthomas/repr v0.2.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
@@ -25,8 +28,6 @@ golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 h1:MGwJjxBy0HJshjDNfLsYO8xpp
 golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/macaroon_test.go
+++ b/macaroon_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/alecthomas/assert/v2"
-	"github.com/stretchr/testify/require"
 	msgpack "github.com/vmihailenco/msgpack/v5"
 )
 
@@ -156,7 +155,7 @@ func TestMacaroons(t *testing.T) {
 		t.Helper()
 
 		mac, err = New(kid, loc, key)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		mac.Add(cavs...)
 
@@ -165,15 +164,15 @@ func TestMacaroons(t *testing.T) {
 		}
 
 		encoded, err = mac.Encode()
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		for _, tp := range tpCavs {
 			found, _, dm, err := dischargeMacaroon(tp.key, tp.loc, encoded)
 			assert.True(t, found)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			dmBuf, err := dm.Encode()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			discharges = append(discharges, dmBuf)
 		}
@@ -186,7 +185,7 @@ func TestMacaroons(t *testing.T) {
 		}
 
 		decoded, err = Decode(encoded)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		decodedCavs = decoded.UnsafeCaveats.Caveats
 	}
@@ -198,7 +197,7 @@ func TestMacaroons(t *testing.T) {
 		}
 
 		verifiedCavs, err = decoded.Verify(key, discharges, nil)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}
 
 	t.Run("decode", func(t *testing.T) {
@@ -293,10 +292,10 @@ func TestMacaroons(t *testing.T) {
 
 		found, _, dm, err := dischargeMacaroon(tpKey, tpLoc, encoded)
 		assert.True(t, found)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		discharges[0], err = dm.Encode()
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		requireVerify(t)
 	})
@@ -341,24 +340,24 @@ func TestMacaroons(t *testing.T) {
 		unboundDischarge := discharges[0]
 
 		cids, err := decoded.ThirdPartyCIDs()
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		cid := cids["other loc"]
 
 		rcid, err := unseal(tpKey, cid)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		wcid := &wireCID{}
-		require.NoError(t, msgpack.Unmarshal(rcid, wcid))
+		assert.NoError(t, msgpack.Unmarshal(rcid, wcid))
 
 		dum, err := Decode(unboundDischarge)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		_, err = dum.verify(wcid.RN, nil, nil, true, nil)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		_, err = dum.verify(wcid.RN, nil, [][]byte{{123}}, true, nil)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("verify - bound discharge token", func(t *testing.T) {
@@ -374,12 +373,12 @@ func TestMacaroons(t *testing.T) {
 
 		found, _, dm, err := dischargeMacaroon(tpKey, tpLoc, encoded)
 		assert.True(t, found)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
-		require.NoError(t, dm.Bind(encoded))
+		assert.NoError(t, dm.Bind(encoded))
 
 		discharges[0], err = dm.Encode()
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		requireVerify(t)
 	})
@@ -397,18 +396,18 @@ func TestMacaroons(t *testing.T) {
 
 		found, _, dm, err := dischargeMacaroon(tpKey, tpLoc, encoded)
 		assert.True(t, found)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
-		require.NoError(t, dm.Bind(encoded))
+		assert.NoError(t, dm.Bind(encoded))
 		dm.Add(&BindToParentToken{0xde, 0xad, 0xbe, 0xef})
 
 		discharges[0], err = dm.Encode()
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		requireDecode(t)
 
 		_, err = decoded.Verify(key, discharges, nil)
-		require.Error(t, err)
+		assert.Error(t, err)
 	})
 }
 
@@ -424,29 +423,29 @@ func Test3pe2e(t *testing.T) {
 			)
 
 			m, err := New(kid, "https://api.fly.io", key)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
-			require.NoError(t, m.Add(cavParent(ActionRead|ActionWrite, 110)))
-			require.NoError(t, m.Add3P(ka, authLoc))
+			assert.NoError(t, m.Add(cavParent(ActionRead|ActionWrite, 110)))
+			assert.NoError(t, m.Add3P(ka, authLoc))
 			rBuf, err := m.Encode()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			rm, err := Decode(rBuf)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			tps, err := rm.ThirdPartyCIDs()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			cid := tps[authLoc]
 			_, dm, err := dischargeCID(ka, authLoc, cid, isProof)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
-			require.NoError(t, dm.Add(cavExpiry(5*time.Minute)))
+			assert.NoError(t, dm.Add(cavExpiry(5*time.Minute)))
 			aBuf, err := dm.Encode()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			verifiedCavs, err := rm.Verify(key, [][]byte{aBuf}, nil)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			_, _, err = dischargeCID(ka, authLoc, cid, isProof)
 			assert.NoError(t, err)
@@ -506,37 +505,37 @@ func TestSimple3P(t *testing.T) {
 			)
 
 			m, err := New(kid, rootLoc, rootKey)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
-			require.NoError(t, m.Add(cavParent(ActionRead, 1010)))
-			require.NoError(t, m.Add3P(ka, authLoc))
+			assert.NoError(t, m.Add(cavParent(ActionRead, 1010)))
+			assert.NoError(t, m.Add3P(ka, authLoc))
 			rBuf, err := m.Encode()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			decoded, err := Decode(rBuf)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			tps, err := decoded.ThirdPartyCIDs()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			cid := tps[authLoc]
 
 			_, dm, err := dischargeCID(ka, authLoc, cid, isProof)
-			require.NoError(t, err)
-			require.NoError(t, dm.Add(cavExpiry(5*time.Minute)))
+			assert.NoError(t, err)
+			assert.NoError(t, dm.Add(cavExpiry(5*time.Minute)))
 			aBuf, err := dm.Encode()
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			_, err = Decode(aBuf)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			verifiedCavs, err := decoded.Verify(rootKey, [][]byte{aBuf}, nil)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			err = verifiedCavs.Validate(&testAccess{
 				parentResource: ptr(uint64(1010)),
 				action:         ActionRead,
 			})
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/resset/errors.go
+++ b/resset/errors.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	ErrResourceUnspecified     = fmt.Errorf("%w: must specify", macaroon.ErrInvalidAccess)
-	ErrUnauthorizedForResource = fmt.Errorf("%w for", macaroon.ErrUnauthorized)
-	ErrUnauthorizedForAction   = fmt.Errorf("%w for", macaroon.ErrUnauthorized)
+	ErrResourceUnspecified        = fmt.Errorf("%w: must specify", macaroon.ErrInvalidAccess)
+	ErrResourcesMutuallyExclusive = fmt.Errorf("%w: resources are mutually exclusive", macaroon.ErrInvalidAccess)
+	ErrUnauthorizedForResource    = fmt.Errorf("%w for", macaroon.ErrUnauthorized)
+	ErrUnauthorizedForAction      = fmt.Errorf("%w for", macaroon.ErrUnauthorized)
 )


### PR DESCRIPTION
1. Alias `Organization`/`Apps` as `DeprecatedOrganization`/`DeprecatedApps`
2. Teach web to do the same
3. Add new `Organization`/`Apps` caveats using internal IDs