### PR TITLE
Handle unregistered caveats

### DIFF
--- a/caveat_set.go
+++ b/caveat_set.go
@@ -130,11 +130,7 @@ func (c *CaveatSet) DecodeMsgpack(dec *msgpack.Decoder) error {
 			return err
 		}
 
-		cav, err := typeToCaveat(CaveatType(t))
-		if err != nil {
-			return err
-		}
-
+		cav := typeToCaveat(CaveatType(t))
 		if err := dec.Decode(cav); err != nil {
 			return err
 		}
@@ -181,10 +177,7 @@ func (c *CaveatSet) UnmarshalJSON(b []byte) error {
 	for i := range jcavs {
 		t := caveatTypeFromString(jcavs[i].Type)
 
-		if c.Caveats[i], _ = typeToCaveat(t); c.Caveats[i] == nil {
-			return fmt.Errorf("bad caveat type: %s", jcavs[i].Type)
-		}
-
+		c.Caveats[i] = typeToCaveat(t)
 		if err := json.Unmarshal(jcavs[i].Body, &c.Caveats[i]); err != nil {
 			return err
 		}

--- a/caveat_test.go
+++ b/caveat_test.go
@@ -19,8 +19,6 @@ func TestCaveatRegistry(t *testing.T) {
 	assert.Equal(t, 1, len(cs.Caveats))
 	assert.Equal(t, c, cs.Caveats[0])
 
-	assert.Error(t, json.Unmarshal(j2, cs))
-
 	RegisterCaveatJSONAlias(cavTestParentResource, "Foobar")
 
 	assert.NoError(t, json.Unmarshal(j1, cs))

--- a/caveats_test.go
+++ b/caveats_test.go
@@ -1,6 +1,8 @@
 package macaroon
 
 import (
+	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -141,6 +143,102 @@ func TestSimple(t *testing.T) {
 			now:            time.Now().Add(-(100 * time.Minute)),
 		},
 	})
+}
+
+type myUnregistered struct {
+	Bar map[string]string `json:"bar"`
+	Foo int               `json:"foo"`
+}
+
+func (c *myUnregistered) CaveatType() CaveatType   { return cavMyUnregistered }
+func (c *myUnregistered) Name() string             { return "MyUnregistered" }
+func (c *myUnregistered) Prohibits(f Access) error { return nil }
+
+func TestUnregisteredCaveatJSON(t *testing.T) {
+	RegisterCaveatType(&myUnregistered{})
+	c := &myUnregistered{Foo: 1, Bar: map[string]string{"a": "b"}}
+	cs := NewCaveatSet(c)
+	b, err := json.Marshal(cs)
+	assert.NoError(t, err)
+	unregisterCaveatType(&myUnregistered{})
+
+	cs2 := NewCaveatSet()
+	err = json.Unmarshal(b, cs2)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(cs2.Caveats))
+
+	uc, ok := cs2.Caveats[0].(*UnregisteredCaveat)
+	assert.True(t, ok)
+	assert.Equal(t, cavMyUnregistered, uc.Type)
+
+	assert.Equal(t,
+		any(map[string]any{
+			"bar": map[string]any{
+				"a": "b",
+			},
+			"foo": float64(1),
+		}),
+		uc.Body,
+	)
+
+	_, err = cs2.MarshalMsgpack()
+	assert.EqualError(t, err, "cannot convert unregistered caveats from JSON to msgpack")
+
+	b2, err := json.Marshal(cs2)
+	assert.NoError(t, err)
+	assert.Equal(t, string(b), string(b2))
+
+	RegisterCaveatType(&myUnregistered{})
+	t.Cleanup(func() { unregisterCaveatType(&myUnregistered{}) })
+
+	cs3 := NewCaveatSet()
+	err = json.Unmarshal(b2, cs3)
+	assert.NoError(t, err)
+	assert.Equal(t, cs, cs3)
+}
+
+func TestUnregisteredCaveatMsgpack(t *testing.T) {
+	RegisterCaveatType(&myUnregistered{})
+	c := &myUnregistered{Foo: 1, Bar: map[string]string{"a": "b"}}
+	cs := NewCaveatSet(c)
+	b, err := cs.MarshalMsgpack()
+	assert.NoError(t, err)
+	unregisterCaveatType(&myUnregistered{})
+
+	cs2, err := DecodeCaveats(b)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(cs2.Caveats))
+
+	uc, ok := cs2.Caveats[0].(*UnregisteredCaveat)
+	assert.True(t, ok)
+	assert.Equal(t, cavMyUnregistered, uc.Type)
+
+	assert.Equal(t,
+		any([]any{
+			map[string]any{
+				"a": "b",
+			},
+			int8(1),
+		}),
+		uc.Body,
+	)
+
+	b2, err := cs2.MarshalMsgpack()
+	assert.NoError(t, err)
+	assert.Equal(t, b, b2)
+
+	_, err = json.Marshal(cs2)
+	assert.EqualError(t, errors.Unwrap(errors.Unwrap(err)), "cannot convert unregistered caveats from msgpack to JSON")
+
+	RegisterCaveatType(&myUnregistered{})
+	t.Cleanup(func() { unregisterCaveatType(&myUnregistered{}) })
+
+	cs3, err := DecodeCaveats(b2)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(cs3.Caveats))
+	mucs := GetCaveats[*myUnregistered](cs3)
+	assert.Equal(t, 1, len(mucs))
+	assert.Equal(t, c, mucs[0])
 }
 
 func ptr[T any](t T) *T {

--- a/macaroon_test.go
+++ b/macaroon_test.go
@@ -27,6 +27,7 @@ func cavExpiry(d time.Duration) Caveat {
 const (
 	cavTestParentResource = iota + CavMinUserDefined
 	cavTestChildResource
+	cavMyUnregistered
 )
 
 type testCaveatParentResource struct {


### PR DESCRIPTION
This allows a macaroon-holder to add caveats they may not understand to a macaroon or 3p caveat