### PR TITLE
Misc

### DIFF
--- a/caveat.go
+++ b/caveat.go
@@ -39,6 +39,7 @@ const (
 	AttestationAuthFlyioUserID
 	AttestationAuthGitHubUserID
 	AttestationAuthGoogleUserID
+	CavAction
 
 	// allocate internal blocks of size 255 here
 	block255Min    CaveatType = 1 << 16

--- a/caveat.go
+++ b/caveat.go
@@ -39,6 +39,9 @@ const (
 	AttestationAuthFlyioUserID
 	AttestationAuthGitHubUserID
 	AttestationAuthGoogleUserID
+	_ // fly.io reserved
+	_ // fly.io reserved
+	_ // fly.io reserved
 
 	// Globally-recognized user-registerable caveat types may be requested via
 	// pull requests to this repository. Add a meaningful name of the caveat

--- a/caveat.go
+++ b/caveat.go
@@ -39,9 +39,12 @@ const (
 	AttestationAuthFlyioUserID
 	AttestationAuthGitHubUserID
 	AttestationAuthGoogleUserID
-	_ // fly.io reserved
-	_ // fly.io reserved
-	_ // fly.io reserved
+
+	// allocate internal blocks of size 255 here
+	block255Min    CaveatType = 1 << 16
+	BlockPetsemMin            = block255Min
+	BlockPetsemMax            = BlockPetsemMin + 0xff
+	block255Max    CaveatType = 1<<17 - 1
 
 	// Globally-recognized user-registerable caveat types may be requested via
 	// pull requests to this repository. Add a meaningful name of the caveat

--- a/flyio/access.go
+++ b/flyio/access.go
@@ -80,3 +80,111 @@ func (f *Access) Validate() error {
 
 	return nil
 }
+
+// OrgIDGetter is an interface allowing other packages to implement Accesses
+// that work with Caveats defined in this package.
+type OrgIDGetter interface {
+	resset.Access
+	GetOrgID() *uint64
+}
+
+var _ OrgIDGetter = (*Access)(nil)
+
+// GetOrgID implements OrgIDGetter.
+func (a *Access) GetOrgID() *uint64 { return a.OrgID }
+
+// AppIDGetter is an interface allowing other packages to implement Accesses
+// that work with Caveats defined in this package.
+type AppIDGetter interface {
+	resset.Access
+	GetAppID() *uint64
+}
+
+var _ AppIDGetter = (*Access)(nil)
+
+// GetAppID implements AppIDGetter.
+func (a *Access) GetAppID() *uint64 { return a.AppID }
+
+// FeatureGetter is an interface allowing other packages to implement Accesses
+// that work with Caveats defined in this package.
+type FeatureGetter interface {
+	resset.Access
+	GetFeature() *string
+}
+
+var _ FeatureGetter = (*Access)(nil)
+
+// GetFeature implements FeatureGetter.
+func (a *Access) GetFeature() *string { return a.Feature }
+
+// VolumeGetter is an interface allowing other packages to implement Accesses
+// that work with Caveats defined in this package.
+type VolumeGetter interface {
+	resset.Access
+	GetVolume() *string
+}
+
+var _ VolumeGetter = (*Access)(nil)
+
+// GetVolume implements VolumeGetter.
+func (a *Access) GetVolume() *string { return a.Volume }
+
+// MachineGetter is an interface allowing other packages to implement Accesses
+// that work with Caveats defined in this package.
+type MachineGetter interface {
+	resset.Access
+	GetMachine() *string
+}
+
+var _ MachineGetter = (*Access)(nil)
+
+// GetMachine implements MachineGetter.
+func (a *Access) GetMachine() *string { return a.Machine }
+
+// MachineFeatureGetter is an interface allowing other packages to implement
+// Accesses that work with Caveats defined in this package.
+type MachineFeatureGetter interface {
+	resset.Access
+	GetMachineFeature() *string
+}
+
+var _ MachineFeatureGetter = (*Access)(nil)
+
+// GetMachineFeature implements MachineFeatureGetter.
+func (a *Access) GetMachineFeature() *string { return a.MachineFeature }
+
+// MutationGetter is an interface allowing other packages to implement Accesses
+// that work with Caveats defined in this package.
+type MutationGetter interface {
+	macaroon.Access
+	GetMutation() *string
+}
+
+var _ MutationGetter = (*Access)(nil)
+
+// GetMutation implements MutationGetter.
+func (a *Access) GetMutation() *string { return a.Mutation }
+
+// SourceMachineGetter is an interface allowing other packages to implement
+// Accesses that work with Caveats defined in this package.
+type SourceMachineGetter interface {
+	macaroon.Access
+	GetSourceMachine() *string
+}
+
+var _ SourceMachineGetter = (*Access)(nil)
+
+// GetSourceMachine implements SourceMachineGetter.
+func (a *Access) GetSourceMachine() *string { return a.SourceMachine }
+
+// ClusterGetter is an interface allowing other packages to implement Accesses
+// that work with Caveats defined in this package.
+type ClusterGetter interface {
+	resset.Access
+	GetCluster() *string
+}
+
+var _ ClusterGetter = (*Access)(nil)
+
+// GetCluster implements ClusterGetter.
+func (a *Access) GetCluster() *string { return a.Cluster }

--- a/flyio/access.go
+++ b/flyio/access.go
@@ -9,9 +9,9 @@ import (
 )
 
 type Access struct {
-	OrgSlug        *string       `json:"org_slug,omitempty"`
-	AppID          *string       `json:"apphid,omitempty"`
 	Action         resset.Action `json:"action,omitempty"`
+	OrgID          *uint64       `json:"orgid,omitempty"`
+	AppID          *uint64       `json:"appid,omitempty"`
 	Feature        *string       `json:"feature,omitempty"`
 	Volume         *string       `json:"volume,omitempty"`
 	Machine        *string       `json:"machine,omitempty"`
@@ -19,10 +19,6 @@ type Access struct {
 	Mutation       *string       `json:"mutation,omitempty"`
 	SourceMachine  *string       `json:"sourceMachine,omitempty"`
 	Cluster        *string       `json:"cluster,omitempty"`
-
-	// deprecated
-	DeprecatedOrgID *uint64 `json:"orgid,omitempty"`
-	DeprecatedAppID *uint64 `json:"appid,omitempty"`
 }
 
 var (
@@ -46,25 +42,18 @@ func (a *Access) Now() time.Time {
 //
 // This ensure that a Access represents a single action taken on a single object.
 func (f *Access) Validate() error {
-	// TODO: require both slug/id to be set once clients are updated.
-	// root-level resources = org
-	if f.DeprecatedOrgID == nil {
+	if f.OrgID == nil {
 		return fmt.Errorf("%w org", resset.ErrResourceUnspecified)
 	}
 
-	// TODO: require both id/hid to be set once clients are updated.
-	if f.AppID != nil && f.DeprecatedAppID == nil {
-		return fmt.Errorf("%w deprecated app id if specifying app id", resset.ErrResourceUnspecified)
-	}
-
 	// org-level resources = apps, features
-	if f.DeprecatedAppID != nil && f.Feature != nil {
+	if f.AppID != nil && f.Feature != nil {
 		return fmt.Errorf("%w: app, org-feature", resset.ErrResourcesMutuallyExclusive)
 	}
 
 	// app-level resources = machines, volumes
 	if f.Machine != nil || f.Volume != nil {
-		if f.DeprecatedAppID == nil {
+		if f.AppID == nil {
 			return fmt.Errorf("%w app if app-owned resource is specified", resset.ErrResourceUnspecified)
 		}
 

--- a/flyio/access_test.go
+++ b/flyio/access_test.go
@@ -14,59 +14,43 @@ func TestAccess(t *testing.T) {
 
 	// orgid required
 	assertError(t, resset.ErrResourceUnspecified, (&Access{}).Validate())
-	assertError(t, resset.ErrResourceUnspecified, (&Access{
-		OrgSlug: ptr("x"),
-	}).Validate())
 	assertError(t, noError, (&Access{
-		DeprecatedOrgID: uptr(1),
+		OrgID: uptr(1),
 	}).Validate())
 
 	// org-level resources are mutually exclusive
 	assertError(t, resset.ErrResourcesMutuallyExclusive, (&Access{
-		DeprecatedOrgID: uptr(1),
-		DeprecatedAppID: uptr(1),
-		Feature:         ptr("x"),
+		OrgID:   uptr(1),
+		AppID:   uptr(1),
+		Feature: ptr("x"),
 	}).Validate())
 	assertError(t, noError, (&Access{
-		DeprecatedOrgID: uptr(1),
-		DeprecatedAppID: uptr(1),
+		OrgID: uptr(1),
+		AppID: uptr(1),
 	}).Validate())
 	assertError(t, noError, (&Access{
-		DeprecatedOrgID: uptr(1),
-		DeprecatedAppID: uptr(1),
+		OrgID: uptr(1),
+		AppID: uptr(1),
 	}).Validate())
 	assertError(t, noError, (&Access{
-		DeprecatedOrgID: uptr(1),
-		Feature:         ptr("x"),
+		OrgID:   uptr(1),
+		Feature: ptr("x"),
 	}).Validate())
 
 	// can't specify clusters without litefs-cloud feature
 	assertError(t, resset.ErrResourceUnspecified, (&Access{
-		DeprecatedOrgID: uptr(1),
-		Cluster:         ptr("foo"),
+		OrgID:   uptr(1),
+		Cluster: ptr("foo"),
 	}).Validate())
 	assertError(t, macaroon.ErrInvalidAccess, (&Access{
-		DeprecatedOrgID: uptr(1),
-		Feature:         ptr("x"),
-		Cluster:         ptr("foo"),
+		OrgID:   uptr(1),
+		Feature: ptr("x"),
+		Cluster: ptr("foo"),
 	}).Validate())
 	assert.NoError(t, (&Access{
-		DeprecatedOrgID: uptr(1),
-		Feature:         ptr(FeatureLFSC),
-		Cluster:         ptr("foo"),
-	}).Validate())
-
-	// can't specify encoded app id without numeric
-	assertError(t, resset.ErrResourceUnspecified, (&Access{
-		DeprecatedOrgID: uptr(1),
-		AppID:           ptr("x"),
-	}).Validate())
-
-	// can (should) specify numeric and encoded app id
-	assertError(t, noError, (&Access{
-		DeprecatedOrgID: uptr(1),
-		AppID:           ptr("x"),
-		DeprecatedAppID: uptr(1),
+		OrgID:   uptr(1),
+		Feature: ptr(FeatureLFSC),
+		Cluster: ptr("foo"),
 	}).Validate())
 }
 

--- a/flyio/caveat_set.go
+++ b/flyio/caveat_set.go
@@ -35,7 +35,7 @@ func OrganizationScope(cs *macaroon.CaveatSet) (uint64, error) {
 
 	orgCS := typedCaveatSet(cavs...)
 
-	if err := orgCS.Validate(&Access{DeprecatedOrgID: &cavs[0].ID, Action: resset.ActionNone}); err != nil {
+	if err := orgCS.Validate(&Access{OrgID: &cavs[0].ID, Action: resset.ActionNone}); err != nil {
 		return 0, err
 	}
 
@@ -64,9 +64,9 @@ func AppScope(cs *macaroon.CaveatSet) []uint64 {
 	appCS := typedCaveatSet(cavs...)
 	maps.DeleteFunc(possibleIDs, func(id uint64, _ bool) bool {
 		err := appCS.Validate(&Access{
-			DeprecatedOrgID: ptr(uint64(999)), // access requires an org
-			Action:          resset.ActionNone,
-			DeprecatedAppID: &id,
+			OrgID:  ptr(uint64(999)), // access requires an org
+			Action: resset.ActionNone,
+			AppID:  &id,
 		})
 
 		return err != nil
@@ -106,10 +106,10 @@ func ClusterScope(cs *macaroon.CaveatSet) []string {
 	clusterCS := typedCaveatSet(cavs...)
 	maps.DeleteFunc(possibleIDs, func(id string, _ bool) bool {
 		err := clusterCS.Validate(&Access{
-			DeprecatedOrgID: ptr(uint64(999)), // access requires an org
-			Action:          resset.ActionNone,
-			Feature:         ptr(FeatureLFSC),
-			Cluster:         &id,
+			OrgID:   ptr(uint64(999)), // access requires an org
+			Action:  resset.ActionNone,
+			Feature: ptr(FeatureLFSC),
+			Cluster: &id,
 		})
 
 		return err != nil
@@ -143,7 +143,7 @@ func AppsAllowing(cs *macaroon.CaveatSet, action resset.Action) (uint64, []uint6
 	// no app restrictions, check that action is allowed on apps in general
 	if appScope == nil {
 		var zeroID uint64
-		if err := cs.Validate(&Access{DeprecatedOrgID: &orgScope, DeprecatedAppID: &zeroID, Action: action}); err != nil {
+		if err := cs.Validate(&Access{OrgID: &orgScope, AppID: &zeroID, Action: action}); err != nil {
 			return 0, empty, err
 		}
 		return orgScope, nil, nil
@@ -157,7 +157,7 @@ func AppsAllowing(cs *macaroon.CaveatSet, action resset.Action) (uint64, []uint6
 	// filter scope to those allowing action
 	ret := make([]uint64, 0, len(appScope))
 	for _, appID := range appScope {
-		if err := cs.Validate(&Access{DeprecatedOrgID: &orgScope, DeprecatedAppID: &appID, Action: action}); err == nil {
+		if err := cs.Validate(&Access{OrgID: &orgScope, AppID: &appID, Action: action}); err == nil {
 			ret = append(ret, appID)
 		}
 	}

--- a/flyio/caveats.go
+++ b/flyio/caveats.go
@@ -64,10 +64,10 @@ func (c *Organization) Prohibits(a macaroon.Access) error {
 	switch {
 	case !isFlyioAccess:
 		return macaroon.ErrInvalidAccess
-	case f.DeprecatedOrgID == nil:
+	case f.OrgID == nil:
 		return fmt.Errorf("%w org", resset.ErrResourceUnspecified)
-	case c.ID != *f.DeprecatedOrgID:
-		return fmt.Errorf("%w org %d, only %d", resset.ErrUnauthorizedForResource, f.DeprecatedOrgID, c.ID)
+	case c.ID != *f.OrgID:
+		return fmt.Errorf("%w org %d, only %d", resset.ErrUnauthorizedForResource, f.OrgID, c.ID)
 	case !f.Action.IsSubsetOf(c.Mask):
 		return fmt.Errorf("%w access %s (%s not allowed)", resset.ErrUnauthorizedForAction, f.Action, f.Action.Remove(c.Mask))
 	default:
@@ -95,7 +95,7 @@ func (c *Apps) Prohibits(a macaroon.Access) error {
 	if !isFlyioAccess {
 		return macaroon.ErrInvalidAccess
 	}
-	return c.Apps.Prohibits(f.DeprecatedAppID, f.Action)
+	return c.Apps.Prohibits(f.AppID, f.Action)
 }
 
 type Volumes struct {

--- a/flyio/caveats.go
+++ b/flyio/caveats.go
@@ -66,7 +66,7 @@ func (c *Organization) Prohibits(a macaroon.Access) error {
 		return macaroon.ErrInvalidAccess
 	case f.GetOrgID() == nil:
 		return fmt.Errorf("%w org", resset.ErrResourceUnspecified)
-	case c.ID != *f.GetOrgID():
+	case c.ID != resset.ZeroID[uint64]() && c.ID != *f.GetOrgID():
 		return fmt.Errorf("%w org %d, only %d", resset.ErrUnauthorizedForResource, *f.GetOrgID(), c.ID)
 	case !f.GetAction().IsSubsetOf(c.Mask):
 		return fmt.Errorf("%w access %s (%s not allowed)", resset.ErrUnauthorizedForAction, f.GetAction(), f.GetAction().Remove(c.Mask))

--- a/flyio/caveats_test.go
+++ b/flyio/caveats_test.go
@@ -55,43 +55,43 @@ func TestNoAdminFeatures(t *testing.T) {
 	}
 
 	yes(&Access{
-		DeprecatedOrgID: uptr(1),
-		Action:          resset.ActionAll,
-		Feature:         ptr("wg"),
+		OrgID:   uptr(1),
+		Action:  resset.ActionAll,
+		Feature: ptr("wg"),
 	})
 
 	yes(&Access{
-		DeprecatedOrgID: uptr(1),
-		Action:          resset.ActionRead,
-		Feature:         ptr("membership"),
+		OrgID:   uptr(1),
+		Action:  resset.ActionRead,
+		Feature: ptr("membership"),
 	})
 
 	yes(&Access{
-		DeprecatedOrgID: uptr(1),
-		Action:          resset.ActionAll,
+		OrgID:  uptr(1),
+		Action: resset.ActionAll,
 	})
 
 	no(&Access{
-		DeprecatedOrgID: uptr(1),
-		Action:          resset.ActionWrite,
-		Feature:         ptr("membership"),
+		OrgID:   uptr(1),
+		Action:  resset.ActionWrite,
+		Feature: ptr("membership"),
 	}, resset.ErrUnauthorizedForAction)
 
 	no(&Access{
-		DeprecatedOrgID: uptr(1),
-		Action:          resset.ActionRead,
-		Feature:         ptr("unknown"),
+		OrgID:   uptr(1),
+		Action:  resset.ActionRead,
+		Feature: ptr("unknown"),
 	}, resset.ErrUnauthorizedForResource)
 
 	no(&Access{
-		DeprecatedOrgID: uptr(1),
-		Action:          resset.ActionNone,
-		Feature:         ptr(""),
+		OrgID:   uptr(1),
+		Action:  resset.ActionNone,
+		Feature: ptr(""),
 	}, resset.ErrUnauthorizedForResource)
 
 	no(&Access{
-		DeprecatedOrgID: uptr(1),
-		Action:          resset.ActionNone,
-		Feature:         ptr(""),
+		OrgID:   uptr(1),
+		Action:  resset.ActionNone,
+		Feature: ptr(""),
 	}, resset.ErrUnauthorizedForResource)
 }

--- a/resset/action_test.go
+++ b/resset/action_test.go
@@ -1,0 +1,19 @@
+package resset
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/superfly/macaroon"
+)
+
+func TestActionCaveat(t *testing.T) {
+	cs := macaroon.NewCaveatSet(cavParent(ActionAll, 123), ptr(ActionRead))
+	assert.NoError(t,
+		cs.Validate(&testAccess{Action: ActionRead, ParentResource: ptr(uint64(123))}),
+	)
+	assert.IsError(t,
+		cs.Validate(&testAccess{Action: ActionWrite, ParentResource: ptr(uint64(123))}),
+		ErrUnauthorizedForAction,
+	)
+}

--- a/resset/if_present_test.go
+++ b/resset/if_present_test.go
@@ -1,11 +1,8 @@
 package resset
 
 import (
-	"encoding/json"
 	"errors"
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/alecthomas/assert/v2"
 	"github.com/superfly/macaroon"
@@ -54,112 +51,4 @@ func TestIfPresent(t *testing.T) {
 	// hit else block (failure)
 	no(ErrUnauthorizedForAction, &testAccess{ParentResource: ptr(uint64(123)), Action: ActionWrite})   // action allowed earlier, disallowed by else
 	no(ErrUnauthorizedForAction, &testAccess{ParentResource: ptr(uint64(123)), Action: ActionControl}) // action only allowed by if
-}
-
-func TestCaveatSerialization(t *testing.T) {
-	cs := macaroon.NewCaveatSet(
-		&IfPresent{Ifs: macaroon.NewCaveatSet(&macaroon.ValidityWindow{NotBefore: 123, NotAfter: 234}), Else: ActionDelete},
-	)
-
-	b, err := json.Marshal(cs)
-	assert.NoError(t, err)
-
-	cs2 := macaroon.NewCaveatSet()
-	err = json.Unmarshal(b, cs2)
-	assert.NoError(t, err)
-	assert.Equal(t, cs, cs2)
-
-	b, err = encode(cs)
-	assert.NoError(t, err)
-	cs2, err = macaroon.DecodeCaveats(b)
-	assert.NoError(t, err)
-	assert.Equal(t, cs, cs2)
-}
-
-const (
-	cavTestParentResource = iota + macaroon.CavMinUserDefined + 10
-	cavTestChildResource
-)
-
-type testCaveatParentResource struct {
-	ID         uint64
-	Permission Action
-}
-
-func cavParent(permission Action, id uint64) macaroon.Caveat {
-	return &testCaveatParentResource{id, permission}
-}
-
-func init()                                                         { macaroon.RegisterCaveatType(&testCaveatParentResource{}) }
-func (c *testCaveatParentResource) CaveatType() macaroon.CaveatType { return cavTestParentResource }
-func (c *testCaveatParentResource) Name() string                    { return "ParentResource" }
-
-func (c *testCaveatParentResource) Prohibits(f macaroon.Access) error {
-	tf, isTestAccess := f.(*testAccess)
-
-	switch {
-	case !isTestAccess:
-		return macaroon.ErrInvalidAccess
-	case tf.ParentResource == nil:
-		return ErrResourceUnspecified
-	case *tf.ParentResource != c.ID:
-		return fmt.Errorf("%w resource", ErrUnauthorizedForResource)
-	case !tf.Action.IsSubsetOf(c.Permission):
-		return fmt.Errorf("%w action", ErrUnauthorizedForAction)
-	default:
-		return nil
-	}
-}
-
-type testCaveatChildResource struct {
-	ID         uint64
-	Permission Action
-}
-
-func cavChild(permission Action, id uint64) macaroon.Caveat {
-	return &testCaveatChildResource{id, permission}
-}
-
-func init()                                                        { macaroon.RegisterCaveatType(&testCaveatChildResource{}) }
-func (c *testCaveatChildResource) CaveatType() macaroon.CaveatType { return cavTestChildResource }
-func (c *testCaveatChildResource) Name() string                    { return "ChildResource" }
-
-func (c *testCaveatChildResource) Prohibits(f macaroon.Access) error {
-	tf, isTestAccess := f.(*testAccess)
-
-	switch {
-	case !isTestAccess:
-		return macaroon.ErrInvalidAccess
-	case tf.ChildResource == nil:
-		return ErrResourceUnspecified
-	case *tf.ChildResource != c.ID:
-		return fmt.Errorf("%w resource", ErrUnauthorizedForResource)
-	case !tf.Action.IsSubsetOf(c.Permission):
-		return fmt.Errorf("%w action", ErrUnauthorizedForAction)
-	default:
-		return nil
-	}
-}
-
-type testAccess struct {
-	Action         Action
-	ParentResource *uint64
-	ChildResource  *uint64
-}
-
-var _ Access = (*testAccess)(nil)
-
-func (f *testAccess) GetAction() Action {
-	return f.Action
-}
-
-func (f *testAccess) Now() time.Time {
-	return time.Now()
-}
-
-func (f *testAccess) Validate() error {
-	if f.ChildResource != nil && f.ParentResource == nil {
-		return ErrResourceUnspecified
-	}
-	return nil
 }

--- a/resset/resset_test.go
+++ b/resset/resset_test.go
@@ -1,0 +1,120 @@
+package resset
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/superfly/macaroon"
+)
+
+func TestCaveatSerialization(t *testing.T) {
+	cs := macaroon.NewCaveatSet(
+		&IfPresent{Ifs: macaroon.NewCaveatSet(&macaroon.ValidityWindow{NotBefore: 123, NotAfter: 234}), Else: ActionDelete},
+		ptr(ActionRead),
+	)
+
+	b, err := json.Marshal(cs)
+	assert.NoError(t, err)
+
+	cs2 := macaroon.NewCaveatSet()
+	err = json.Unmarshal(b, cs2)
+	assert.NoError(t, err)
+	assert.Equal(t, cs, cs2)
+
+	b, err = encode(cs)
+	assert.NoError(t, err)
+	cs2, err = macaroon.DecodeCaveats(b)
+	assert.NoError(t, err)
+	assert.Equal(t, cs, cs2)
+}
+
+const (
+	cavTestParentResource = iota + macaroon.CavMinUserDefined + 10
+	cavTestChildResource
+)
+
+type testCaveatParentResource struct {
+	ID         uint64
+	Permission Action
+}
+
+func cavParent(permission Action, id uint64) macaroon.Caveat {
+	return &testCaveatParentResource{id, permission}
+}
+
+func init()                                                         { macaroon.RegisterCaveatType(&testCaveatParentResource{}) }
+func (c *testCaveatParentResource) CaveatType() macaroon.CaveatType { return cavTestParentResource }
+func (c *testCaveatParentResource) Name() string                    { return "ParentResource" }
+
+func (c *testCaveatParentResource) Prohibits(f macaroon.Access) error {
+	tf, isTestAccess := f.(*testAccess)
+
+	switch {
+	case !isTestAccess:
+		return macaroon.ErrInvalidAccess
+	case tf.ParentResource == nil:
+		return ErrResourceUnspecified
+	case *tf.ParentResource != c.ID:
+		return fmt.Errorf("%w resource", ErrUnauthorizedForResource)
+	case !tf.Action.IsSubsetOf(c.Permission):
+		return fmt.Errorf("%w action", ErrUnauthorizedForAction)
+	default:
+		return nil
+	}
+}
+
+type testCaveatChildResource struct {
+	ID         uint64
+	Permission Action
+}
+
+func cavChild(permission Action, id uint64) macaroon.Caveat {
+	return &testCaveatChildResource{id, permission}
+}
+
+func init()                                                        { macaroon.RegisterCaveatType(&testCaveatChildResource{}) }
+func (c *testCaveatChildResource) CaveatType() macaroon.CaveatType { return cavTestChildResource }
+func (c *testCaveatChildResource) Name() string                    { return "ChildResource" }
+
+func (c *testCaveatChildResource) Prohibits(f macaroon.Access) error {
+	tf, isTestAccess := f.(*testAccess)
+
+	switch {
+	case !isTestAccess:
+		return macaroon.ErrInvalidAccess
+	case tf.ChildResource == nil:
+		return ErrResourceUnspecified
+	case *tf.ChildResource != c.ID:
+		return fmt.Errorf("%w resource", ErrUnauthorizedForResource)
+	case !tf.Action.IsSubsetOf(c.Permission):
+		return fmt.Errorf("%w action", ErrUnauthorizedForAction)
+	default:
+		return nil
+	}
+}
+
+type testAccess struct {
+	Action         Action
+	ParentResource *uint64
+	ChildResource  *uint64
+}
+
+var _ Access = (*testAccess)(nil)
+
+func (f *testAccess) GetAction() Action {
+	return f.Action
+}
+
+func (f *testAccess) Now() time.Time {
+	return time.Now()
+}
+
+func (f *testAccess) Validate() error {
+	if f.ChildResource != nil && f.ParentResource == nil {
+		return ErrResourceUnspecified
+	}
+	return nil
+}


### PR DESCRIPTION
A few changes lumped together:

- Give up on deprecating numeric database IDs in favor of public identifiers
- Allow multiple trusted 3p keys in verification to facilitate key rotation
- Use interfaces instead of `flyio.Access` struct in validation to allow other packages to reuse `flyio` caveats