### PR TITLE
Add caveats to restrict command execution.

### DIFF
--- a/caveat.go
+++ b/caveat.go
@@ -41,7 +41,6 @@ const (
 	AttestationAuthGoogleUserID
 	CavAction
 	CavFlyioCommands
-	CavFlyioCommandsArgs
 
 	// allocate internal blocks of size 255 here
 	block255Min    CaveatType = 1 << 16

--- a/caveat.go
+++ b/caveat.go
@@ -40,6 +40,8 @@ const (
 	AttestationAuthGitHubUserID
 	AttestationAuthGoogleUserID
 	CavAction
+	CavFlyioCommands
+	CavFlyioCommandsArgs
 
 	// allocate internal blocks of size 255 here
 	block255Min    CaveatType = 1 << 16

--- a/flyio/access.go
+++ b/flyio/access.go
@@ -19,6 +19,7 @@ type Access struct {
 	Mutation       *string       `json:"mutation,omitempty"`
 	SourceMachine  *string       `json:"sourceMachine,omitempty"`
 	Cluster        *string       `json:"cluster,omitempty"`
+	Command        []string      `json:"command,omitempty"`
 }
 
 var (
@@ -188,3 +189,15 @@ var _ ClusterGetter = (*Access)(nil)
 
 // GetCluster implements ClusterGetter.
 func (a *Access) GetCluster() *string { return a.Cluster }
+
+// CommandGetter is an interface allowing other packages to implement Accesses
+// that work with Caveats defined in this package.
+type CommandGetter interface {
+	macaroon.Access
+	GetCommand() []string
+}
+
+var _ CommandGetter = (*Access)(nil)
+
+// GetCommand implements CommandGetter.
+func (a *Access) GetCommand() []string { return a.Command }

--- a/flyio/caveats.go
+++ b/flyio/caveats.go
@@ -358,9 +358,10 @@ func (c *Commands) Prohibits(a macaroon.Access) error {
 			continue
 		}
 		found = true
+		break
 	}
 	if !found {
-		return fmt.Errorf("%w commands %s", resset.ErrUnauthorizedForResource, commandArgs)
+		return fmt.Errorf("%w commands %v", resset.ErrUnauthorizedForResource, commandArgs)
 	}
 
 	return nil


### PR DESCRIPTION
- Add Commands and CommandsArgs caveats
  - Commands restricts the program name only.
  - CommandsArgs also restricts the command arguments.
  - Both are allowed within IfPresent.
- Update Mutations to work with IfPresent.
