### PR TITLE
Add concept of "roles"

### DIFF
--- a/caveat.go
+++ b/caveat.go
@@ -35,7 +35,7 @@ const (
 	CavAuthConfineGoogleHD
 	CavAuthConfineGitHubOrg
 	CavAuthMaxValidity
-	CavNoAdminFeatures
+	CavFlyioIsMember
 	AttestationAuthFlyioUserID
 	AttestationAuthGitHubUserID
 	AttestationAuthGoogleUserID
@@ -43,6 +43,7 @@ const (
 	CavFlyioCommands
 	CavFlyioAppFeatureSet
 	CavFlyioStorageObjects
+	CavAllowedRoles
 
 	// allocate internal blocks of size 255 here
 	block255Min    CaveatType = 1 << 16

--- a/flyio/errors.go
+++ b/flyio/errors.go
@@ -1,0 +1,11 @@
+package flyio
+
+import (
+	"fmt"
+
+	"github.com/superfly/macaroon"
+)
+
+var (
+	ErrUnauthorizedForRole = fmt.Errorf("%w for role", macaroon.ErrUnauthorized)
+)

--- a/internal/test-vectors/test_vectors.go
+++ b/internal/test-vectors/test_vectors.go
@@ -134,7 +134,7 @@ var caveats = macaroon.NewCaveatSet(
 		0xDE, 0xAD, 0xBE, 0xEF,
 		123,
 	})),
-	&flyio.NoAdminFeatures{},
+	&flyio.IsMember{},
 	&flyio.Organization{ID: 123, Mask: resset.ActionAll},
 )
 


### PR DESCRIPTION
When fly.io is acting as a third party, it's hard for us to communicate to the first party whether the user is an admin. Internally, we do this with `NoAdminFeatures`, but third parties won't have the concept of organization features in their access structs.

This PR moves `NoAdminFeatures` into the top-level package and renames it `NotAdmin`. Instead of enforcing the caveat based on org-features, the access must implement a method specifying what roles are required for the access. The logic of admin-only org features then lives in the access instead of in the caveat. This should all be backwards compatible and also allows for further role-based caveats.

The simpler alternative I considered was to just have the access implement a `RequiresAdmin() bool` method for the sole purpose of interacting with the `NotAdmin` caveat. This would work fine too, but is a bit less flexible and would require more effort if we ever want to add additional roles in the future.

This raises the question though of whether adding RBAC concepts to macaroons is dumb. Thoughts?