### PR TITLE
Msgpack fix 😡

### DIFF
--- a/caveats.go
+++ b/caveats.go
@@ -1,6 +1,7 @@
 package macaroon
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -126,8 +127,17 @@ func (c UnregisteredCaveat) MarshalMsgpack() ([]byte, error) {
 }
 
 func (c *UnregisteredCaveat) UnmarshalMsgpack(data []byte) error {
+	dec := msgpack.GetDecoder()
+	defer msgpack.PutDecoder(dec)
+
+	dec.Reset(bytes.NewReader(data))
+	dec.SetMapDecoder(func(d *msgpack.Decoder) (interface{}, error) {
+		return d.DecodeUntypedMap()
+	})
+
 	c.RawMsgpack = data
-	return msgpack.Unmarshal(data, &c.Body)
+
+	return dec.Decode(&c.Body)
 }
 
 func (c UnregisteredCaveat) MarshalJSON() ([]byte, error) {

--- a/caveats_test.go
+++ b/caveats_test.go
@@ -146,8 +146,8 @@ func TestSimple(t *testing.T) {
 }
 
 type myUnregistered struct {
-	Bar map[string]string `json:"bar"`
-	Foo int               `json:"foo"`
+	Bar map[int]string `json:"bar"`
+	Foo int            `json:"foo"`
 }
 
 func (c *myUnregistered) CaveatType() CaveatType   { return cavMyUnregistered }
@@ -156,7 +156,7 @@ func (c *myUnregistered) Prohibits(f Access) error { return nil }
 
 func TestUnregisteredCaveatJSON(t *testing.T) {
 	RegisterCaveatType(&myUnregistered{})
-	c := &myUnregistered{Foo: 1, Bar: map[string]string{"a": "b"}}
+	c := &myUnregistered{Foo: 1, Bar: map[int]string{1: "b"}}
 	cs := NewCaveatSet(c)
 	b, err := json.Marshal(cs)
 	assert.NoError(t, err)
@@ -174,7 +174,7 @@ func TestUnregisteredCaveatJSON(t *testing.T) {
 	assert.Equal(t,
 		any(map[string]any{
 			"bar": map[string]any{
-				"a": "b",
+				"1": "b",
 			},
 			"foo": float64(1),
 		}),
@@ -199,7 +199,7 @@ func TestUnregisteredCaveatJSON(t *testing.T) {
 
 func TestUnregisteredCaveatMsgpack(t *testing.T) {
 	RegisterCaveatType(&myUnregistered{})
-	c := &myUnregistered{Foo: 1, Bar: map[string]string{"a": "b"}}
+	c := &myUnregistered{Foo: 1, Bar: map[int]string{1: "b"}}
 	cs := NewCaveatSet(c)
 	b, err := cs.MarshalMsgpack()
 	assert.NoError(t, err)
@@ -215,8 +215,8 @@ func TestUnregisteredCaveatMsgpack(t *testing.T) {
 
 	assert.Equal(t,
 		any([]any{
-			map[string]any{
-				"a": "b",
+			map[any]any{
+				int8(1): "b",
 			},
 			int8(1),
 		}),


### PR DESCRIPTION
This is apparently expected behavior? 

```go
func TestMsgpack(t *testing.T) {
	v := map[uint64]uint64{1: 1}
	b, err := msgpack.Marshal(v)
	assert.NoError(t, err)

	var vv any
	assert.NoError(t, msgpack.Unmarshal(b, &vv))
}
```

```
--- FAIL: TestMsgpack (0.00s)
    main_test.go:16: Did not expect an error but got:
        msgpack: invalid code=cf decoding string/bytes length
```